### PR TITLE
Removed dummy parking data

### DIFF
--- a/sources/bietigheim_bissingen.geojson
+++ b/sources/bietigheim_bissingen.geojson
@@ -72,23 +72,6 @@
     {
       "type": "Feature",
       "properties": {
-        "uid": "virtuelles Parkhaus am Standort KI_1-2",
-        "name": "virtuelles Parkhaus am Standort KI_1-2",
-        "address": "",
-        "capacity": 100,
-        "has_realtime_data": true
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.12256,
-          48.95013
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
         "uid": "Parkhaus Turmstr.",
         "name": "Parkhaus Turmstr.",
         "address": "",


### PR DESCRIPTION
This PR removes ```virtuelles Parkhaus am Standort KI_1-2``` which is a dummy data, and according to the city of Bietigheim-Bissingen, it is a virtual parking place not for the public.